### PR TITLE
Change minimum ms to wait after last key pressed

### DIFF
--- a/src/preferences_dialog.py
+++ b/src/preferences_dialog.py
@@ -221,7 +221,7 @@ after the last key\npress before enabling the touchpad') + ':')
         #
         self.interval = Gtk.SpinButton()
         self.interval.set_adjustment(
-            Gtk.Adjustment(500, 300, 10000, 100, 1000, 0))
+            Gtk.Adjustment(500, 10, 10000, 100, 1000, 0))
         grid2.attach(self.interval, 1, 6, 1, 1)
 
         vbox3 = Gtk.VBox(spacing=5)


### PR DESCRIPTION
Trimming the minimum ms to wait after last key pressed down from 300 to 10 I think will make for better usability - unless there is another reason the minimum was set to 300 that I'm not aware of.

(Love this utility, btw, great work!)