### PR TITLE
Change the src path added to be with respect to the script

### DIFF
--- a/bin/touchpad-indicator
+++ b/bin/touchpad-indicator
@@ -29,7 +29,7 @@ if __name__ == '__main__':
         sys.path.insert(1, '/usr/share/touchpad-indicator')
     else:
         sys.path.insert(1, os.path.normpath(
-            os.path.join(os.getcwd(), '../src')))
+            os.path.join(os.path.dirname(__file__), '../src')))
     ####################################################################
     from touchpadindicator import main
     ####################################################################


### PR DESCRIPTION
Currently the touchpad-indicator script adds the ../src path relative to where the command is being run from, not to where the script sits. This means that if you try to run it like 
```
$ bin/touchpad-indicator
```
it will fail, and you have to be in the bin directory itself for it to work. This patch changes it so that you can run it from anywhere.