### PR TITLE
Make the list of faulty devices expandable 

### DIFF
--- a/src/comun.py
+++ b/src/comun.py
@@ -62,7 +62,12 @@ PARAMS = {
     'left-bottom-corner': 0,
     'one-finger-tap': 0,
     'two-finger-tap': 0,
-    'three-finger-tap': 0
+    'three-finger-tap': 0,
+    'faulty-devices' : ['11/2/a/0',  # TPPS/2 IBM TrackPoint
+                  '11/2/5/7326',  # ImPS/2 ALPS GlidePoint
+                  '11/2/1/0',
+                  '11/2/6/0', # ImExPS/2
+                  ]
 }
 
 # check if running from source

--- a/src/preferences_dialog.py
+++ b/src/preferences_dialog.py
@@ -187,7 +187,13 @@ class PreferencesDialog(Gtk.Dialog):
         grid2.attach(label, 0, 0, 1, 1)
         checkbutton2box = Gtk.HBox()
         self.checkbutton2 = Gtk.Switch()
-        checkbutton2box.pack_start(self.checkbutton2, False, False, 0)
+        checkbutton2box.pack_start(self.checkbutton2, False, False, 2)
+        these_are_not_mice_button = Gtk.Button.new_with_label(_('I declare that there are no mice plugged in'))
+        these_are_not_mice_button.set_tooltip_text(_("If Touchpad Indicator is not " \
+            "re-enabling the touchpad when you unplug your mouse, it might help to unplug all " \
+            "mice and click on this"))
+        these_are_not_mice_button.connect('clicked', self.on_invalid_mice_button)
+        checkbutton2box.pack_end(these_are_not_mice_button, True, True, 0)
         grid2.attach(checkbutton2box, 1, 0, 1, 1)
 
         label = Gtk.Label(_('On Touchpad Indicator starts:'))
@@ -590,6 +596,10 @@ after the last key\npress before enabling the touchpad') + ':')
         if self.checkbutton3.get_active() and self.checkbutton4.get_active():
             self.checkbutton3.set_active(False)
 
+    def on_invalid_mice_button(self, widget):
+        import watchdog
+        watchdog.blacklist_every_current_mouse()
+
     def close_application(self, widget):
         self.destroy()
 
@@ -868,6 +878,9 @@ touchpad-indicator')
                 configuration.set('speed', self.speed.get_value())
             elif tipo == EVDEV:
                 configuration.set('speed', self.speed.get_value())
+
+        import watchdog
+        configuration.set('faulty-devices', list(watchdog.faulty_devices))
 
         configuration.save()
         desktop_environment = get_desktop_environment()

--- a/src/touchpadindicator.py
+++ b/src/touchpadindicator.py
@@ -314,6 +314,12 @@ class TouchpadIndicator(dbus.service.Object):
         self.on_start = configuration.get('on_start')
         self.on_end = configuration.get('on_end')
 
+        faulty_devices = configuration.get('faulty-devices')
+        if faulty_devices:
+            import watchdog
+            watchdog.blacklist_products(faulty_devices)
+
+
         self.ICON = comun.ICON
         self.active_icon = comun.STATUS_ICON[configuration.get('theme')][0]
         self.attention_icon = comun.STATUS_ICON[configuration.get('theme')][1]


### PR DESCRIPTION
This may fix issue #25. It does for me

In some laptops, there are built-in devices that are seen as mice by udev, which means that the trackpad is not re-enabled when real USB mice are disconnected. In my case, an ASUS ROG Strix reports some ROG macro key device as a mouse.
    
This patch adds a button in the configuration that lets a user tell touchpad indicator that no real mouse is plugged in, so that every device detected can be added to the list of faulty devices and ignored from then on. The faulty device list is then saved to the configuration file

I wanted to align the button to the right, but my GTK-Foo is extremely weak and nothing I find on Google works. 