### PR TITLE
Guard against missing xinput IDS

### DIFF
--- a/src/preferences_dialog.py
+++ b/src/preferences_dialog.py
@@ -292,7 +292,7 @@ after the last key\npress before enabling the touchpad') + ':')
 
         tp = Touchpad()
         if tp.is_there_touchpad():
-            tipo = tp._get_type(tp._get_ids()[0])
+            tipo = tp.get_driver()
             if tipo == SYNAPTICS:
                 label = Gtk.Label(_('Touchpad speed?'))
                 label.set_alignment(0, 0.5)
@@ -745,7 +745,7 @@ touchpad-indicator')
         self.checkbutton46.set_active(configuration.get('natural_scrolling'))
         tp = Touchpad()
         if tp.is_there_touchpad():
-            tipo = tp._get_type(tp._get_ids()[0])
+            tipo = tp.get_driver()
             if tipo == SYNAPTICS:
                 self.two_finger_scrolling.set_active(
                     configuration.get('two_finger_scrolling'))
@@ -820,7 +820,7 @@ touchpad-indicator')
         configuration.set('natural_scrolling', self.checkbutton46.get_active())
         tp = Touchpad()
         if tp.is_there_touchpad():
-            tipo = tp._get_type(tp._get_ids()[0])
+            tipo = tp.get_driver()
             if tipo == SYNAPTICS:
                 configuration.set(
                     'two_finger_scrolling',

--- a/src/touchpad.py
+++ b/src/touchpad.py
@@ -32,6 +32,7 @@ TOUCHPADS = ['touchpad', 'glidepoint', 'fingersensingpad', 'bcm5974',
 SYNAPTICS = 0
 LIBINPUT = 1
 EVDEV = 2
+UNRECOGNISED = -1
 
 TWO_FINGERS = 0
 EDGE = 1
@@ -154,11 +155,20 @@ class Touchpad(object):
                 if matches is not None:
                     if str(matches.group(0)) == 'evdev':
                         return EVDEV
-        return -1
+        return UNRECOGNISED
 
     def _get_type(self, id):
         test_str = run('xinput --list-props %s' % (id)).lower()
         return self._get_type_from_string(test_str)
+
+    def get_driver(self):
+        """
+        Return touchpad's driver
+        """
+        ids = self._get_ids()
+        if ids:
+            return self._get_type(ids[0])
+        return UNRECOGNISED
 
     def has_tapping(self):
         ids = self._get_ids()

--- a/src/touchpadindicator.py
+++ b/src/touchpadindicator.py
@@ -341,7 +341,7 @@ class TouchpadIndicator(dbus.service.Object):
         self.touchpad.set_natural_scrolling_for_all(
             configuration.get('natural_scrolling'))
         self.touchpad.set_speed(configuration.get('speed') / 100.0)
-        tipo = self.touchpad._get_type(self.touchpad._get_ids()[0])
+        tipo = self.touchpad.get_driver()
         if tipo == LIBINPUT:
             if self.touchpad.has_tapping():
                 self.touchpad.set_tapping(configuration.get('tapping'))
@@ -399,9 +399,9 @@ class TouchpadIndicator(dbus.service.Object):
             self.launch_watchdog()
         # time.sleep(1)
         if self.on_mouse_plugged and is_mouse_plugged():
-                print('===', 1, '===')
-                self.set_touch_enabled(False, False)
-                self.change_state_item.set_sensitive(False)
+            print('===', 1, '===')
+            self.set_touch_enabled(False, False)
+            self.change_state_item.set_sensitive(False)
         else:
             print('===', 2, '===')
             if is_on_start is True:


### PR DESCRIPTION
Some parts of the code assume that there will be touchpad IDs found by xinput when trying to find the
touchpad's driver. This patch wraps that code into something that won't crash when this isn't found.
It also makes the code a little bit nicer

This should fix issue #24 