### PR TITLE
Add Cypress APA touchpad; verified on Acer C-720 Chromebook

### DIFF
--- a/src/touchpad.py
+++ b/src/touchpad.py
@@ -27,7 +27,8 @@ import time
 
 TOUCHPADS = ['touchpad', 'glidepoint', 'fingersensingpad', 'bcm5974',
              'dll0665', 'dll05e3', 'cyps/2', 'alpsps/2', 'imexps/2',
-             'synaptics', 'elantech', 'imps/2', 'dll07a8', 'dll077c']
+             'synaptics', 'elantech', 'imps/2', 'dll07a8', 'dll077c',
+             'cypress apa']
 
 SYNAPTICS = 0
 LIBINPUT = 1


### PR DESCRIPTION
I run Linux Mint on an Acer C-720 (works great). On earlier versions touchpad-indicator worked fine, and is very useful because of the fairly awful touchpad. On Mint 19.2 it stopped working. I diagnosed the problem - before the xinput report included the string Synaptics, on 19.2 it reported:

% xinput list-props 12
Device 'Cypress APA Trackpad (cyapa)':
	Device Enabled (143):	0
	Coordinate Transformation Matrix (145):	1.000000, 0.000000, 0.000000, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, 1.000000
	libinput Tapping Enabled (278):	1
	libinput Tapping Enabled Default (279):	0
	libinput Tapping Drag Enabled (280):	1
	libinput Tapping Drag Enabled Default (281):	1
	libinput Tapping Drag Lock Enabled (282):	0
	libinput Tapping Drag Lock Enabled Default (283):	0
	libinput Tapping Button Mapping Enabled (284):	1, 0
	libinput Tapping Button Mapping Default (285):	1, 0
	libinput Natural Scrolling Enabled (286):	1
	libinput Natural Scrolling Enabled Default (287):	0
	libinput Disable While Typing Enabled (288):	1
	libinput Disable While Typing Enabled Default (289):	1
	libinput Scroll Methods Available (290):	1, 1, 0
	libinput Scroll Method Enabled (291):	1, 0, 0
	libinput Scroll Method Enabled Default (292):	1, 0, 0
	libinput Click Methods Available (293):	1, 1
	libinput Click Method Enabled (294):	1, 0
	libinput Click Method Enabled Default (295):	0, 1
	libinput Middle Emulation Enabled (296):	0
	libinput Middle Emulation Enabled Default (297):	0
	libinput Accel Speed (298):	0.000000
	libinput Accel Speed Default (299):	0.000000
	libinput Left Handed Enabled (300):	0
	libinput Left Handed Enabled Default (301):	0
	libinput Send Events Modes Available (263):	1, 1
	libinput Send Events Mode Enabled (264):	0, 0
	libinput Send Events Mode Enabled Default (265):	0, 0
	Device Node (266):	"/dev/input/event15"
	Device Product ID (267):	0, 0
	libinput Drag Lock Buttons (302):	<no items>
	libinput Horizontal Scroll Enabled (303):	0
